### PR TITLE
Use classifiers to specify the license.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,9 @@ setuptools.setup(
     url="https://github.com/thesixnetwork/SIXEcho",
     packages=setuptools.find_packages(),
     install_requires=REQUIRED_PACKAGES,
-    license='MIT',
     test_suite='nose.collector',
     tests_require=['nose'],
+    classifiers=[
+        'License :: OSI Approved :: MIT License'
+    ],
 )


### PR DESCRIPTION
Classifiers are a standard way of specifying a license, and make it easy
for automated tools to properly detect the license of the package.

The "license" field should only be used if the license has no
corresponding Trove classifier.